### PR TITLE
Reusable workflows to help with react app deployment

### DIFF
--- a/.github/workflows/create_env_file_from_cdk_json.yml
+++ b/.github/workflows/create_env_file_from_cdk_json.yml
@@ -7,6 +7,8 @@ jobs:
   create_env_file_from_cdk_json:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout codebase
+        uses: actions/checkout@v3
       - name: Convert cdk.json to .env file
         run: |
           set -eo pipefail
@@ -25,3 +27,9 @@ jobs:
             echo "### :red_circle: Error creating .env file for branch: $(echo $CURRENT_GIT_BRANCH)" >> $GITHUB_STEP_SUMMARY
             exit 126
           fi
+      - name: Store .env artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: env_file
+          path: ${{ github.workspace }}/.env
+          retention-days: 5

--- a/.github/workflows/create_env_file_from_cdk_json.yml
+++ b/.github/workflows/create_env_file_from_cdk_json.yml
@@ -1,0 +1,27 @@
+name: Create .env file from cdk.json
+
+on:
+  workflow_call:
+
+jobs:
+  create_env_file_from_cdk_json:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Convert cdk.json to .env file
+        run: |
+          set -eo pipefail
+
+          # Get the current branch either from CI environment or from locally checked out branch
+          CURRENT_GIT_BRANCH="${GITHUB_HEAD_REF:-$(git symbolic-ref --short HEAD)}"
+
+          # Build a .env using the current git branch, include `stackId`
+          jq -r --arg CURRENT_GIT_BRANCH "$CURRENT_GIT_BRANCH" '.context.globals + (.context.environments[] | select(.branchName | contains($CURRENT_GIT_BRANCH))) | . + { stackId: "\(.appName)\(.environment | (.[:1] | ascii_upcase) + (.[1:]))" } | to_entries | .[] | "\(.key)=\(.value)"' cdk.json > .env
+
+          # Check that env file has data in it, if empty this script should die
+          if [ -s .env ]; then
+            echo "### :white_check_mark: Created .env file for branch: $(echo $CURRENT_GIT_BRANCH)" >> $GITHUB_STEP_SUMMARY
+            cat .env >> $GITHUB_STEP_SUMMARY
+          else
+            echo "### :red_circle: Error creating .env file for branch: $(echo $CURRENT_GIT_BRANCH)" >> $GITHUB_STEP_SUMMARY
+            exit 126
+          fi

--- a/.github/workflows/get_outputs_from_cloudformation_stack.yml
+++ b/.github/workflows/get_outputs_from_cloudformation_stack.yml
@@ -1,0 +1,67 @@
+name: Get outputs from a cloudformation stack and create a .stack_outputs artifact
+
+on:
+  workflow_call:
+    secrets:
+      aws_secret_access_key:
+        required: true
+      aws_access_key_id:
+        required: true
+      aws_region:
+        required: true
+    inputs:
+      outputs:
+        description: A comma-delimited string of stack Output names to be fetched
+        required: true
+        type: string
+
+jobs:
+  create_stack_outputs_artifact:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout codebase
+        uses: actions/checkout@v3
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1-node16
+        with:
+          aws-access-key-id: ${{ secrets.aws_access_key_id }}
+          aws-secret-access-key: ${{ secrets.aws_secret_access_key }}
+          aws-region: ${{ secrets.aws_region }}
+      - name: Get and export the Cloudformation stack outputs
+        env:
+          OUTPUTS_TO_FETCH: ${{ inputs.outputs }}
+        run: |
+          set -eo pipefail
+
+          # Get the current branch either from CI environment or from locally checked out branch
+          CURRENT_GIT_BRANCH="${GITHUB_HEAD_REF:-$(git symbolic-ref --short HEAD)}"
+
+          # Build stackId from cdk.json
+          STACK_ID=$(jq -r --arg CURRENT_GIT_BRANCH "$CURRENT_GIT_BRANCH" '.context.globals + (.context.environments[] | select(.branchName | contains($CURRENT_GIT_BRANCH))) | "\(.appName)\(.environment | (.[:1] | ascii_upcase) + (.[1:]))"' cdk.json)
+
+          # Check that stackId is available and explicitly set it to a new variable
+          if [[ -z "${STACK_ID}" ]]; then
+            echo "### :red_circle: No stackId value found, goodbye." >> $GITHUB_STEP_SUMMARY
+            exit 126
+          else
+            : # noop
+          fi
+
+          # Get the data from AWS Cloudformation
+          GREP_INPUTS=$(echo ${OUTPUTS_TO_FETCH} | sed "s/,/\\\|/g")
+          aws cloudformation describe-stacks --stack-name ${STACK_ID} --query "Stacks[0].Outputs[]" | jq -r '.[] | "\(.OutputKey)=\(.OutputValue)"' | grep ${GREP_INPUTS} > .stack_outputs
+
+          # Check that output values were found and set on GITHUB_ENV
+          if [ -s .stack_outputs ]; then
+            echo "### :white_check_mark: .stack_outputs file created:" >> $GITHUB_STEP_SUMMARY
+            cat .stack_outputs >> $GITHUB_STEP_SUMMARY
+          else
+            echo "### :red_circle: No output values from in stack, goodbye." >> $GITHUB_STEP_SUMMARY
+            exit 126
+          fi
+      - name: Upload .stack_outputs artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: stack_outputs
+          path: ${{ github.workspace }}/.stack_outputs
+          retention-days: 5


### PR DESCRIPTION
These new actions will be helpful in CDK projects where a react app is built and deployed with an example workflow being:

1. react app is built (requires a .env file)
2. cdk infrastructure is deployed which builds an S3 bucket and a Cloudfront distribution
3. app is uploaded to the s3 bucket (bucket ARN is needed from step 2)
4. cloudfront cache is invalidated (distribution ID is needed from step 2)

### `create_env_file_from_cdk_json`

1. figures out the current git branch
5. combines `globals` and environment-specific config from cdk.json into a single object
6. computes the proper `stackId` value and adds it. e.g. `QaDashboardDev`
7. converts this object into a list of environment variables
8. writes them to `.env`
9. uploads the `.env` artifact as `env_file`

### `get_outputs_from_cloudformation_stack`

1. figures out the current git branch
2. computes the `stackId` value
3. queries cloudformation for stack metadata
4. filters the returned stack outputs to just the ones requested
5. converts the values into a list of environment variables
6. writes them to `.stack_outputs`
10. uploads the `.stack_outputs` artifact as `stack_outputs`
