### PR TITLE
`node18` -> `main`

### DIFF
--- a/.github/workflows/deploy_with_cdk.yml
+++ b/.github/workflows/deploy_with_cdk.yml
@@ -1,10 +1,6 @@
 # Deploys using CDK
 name: Deploy with CDK
 
-permissions:
-  id-token: write
-  contents: read
-
 on:
   # Runs workflow when called from another workflow (referred to as a "called" workflow)
   workflow_call:

--- a/.github/workflows/deploy_with_cdk.yml
+++ b/.github/workflows/deploy_with_cdk.yml
@@ -9,14 +9,17 @@ on:
         required: true
       private_gh_packages_token:
         required: true
-      aws_access_key_id:
-        required: true
-      aws_secret_access_key:
-        required: true
     inputs:
       region:
         required: true
         type: string
+      aws_role_to_assume:
+        required: true
+        type: string
+      aws_role_duration_seconds:
+        required: false
+        type: number
+        default: 1200
 
 jobs:
  deploy:
@@ -39,10 +42,13 @@ jobs:
 
     - name: Install npm dependencies
       run: npm ci
+    
+    - name: Configure AWS Creds
+      uses: aws-actions/configure-aws-credentials@v1-node16
+      with:
+        role-to-assume: ${{ inputs.aws_role_to_assume }}
+        role-duration-seconds: ${{ inputs.aws_role_duration_seconds }} 
+        aws-region: ${{ inputs.region }}
 
     - name: CDK Deploy
       run: npx cdk deploy --require-approval never "*"
-      env:
-        AWS_ACCESS_KEY_ID: ${{ secrets.aws_access_key_id }}
-        AWS_SECRET_ACCESS_KEY: ${{ secrets.aws_secret_access_key }}
-        AWS_DEFAULT_REGION: ${{ inputs.region }}

--- a/.github/workflows/deploy_with_cdk.yml
+++ b/.github/workflows/deploy_with_cdk.yml
@@ -13,7 +13,7 @@ on:
       private_gh_packages_token:
         required: true
     inputs:
-      region:
+      aws_region:
         required: true
         type: string
       aws_role_to_assume:
@@ -51,7 +51,7 @@ jobs:
       with:
         role-to-assume: ${{ inputs.aws_role_to_assume }}
         role-duration-seconds: ${{ inputs.aws_role_duration_seconds }} 
-        aws-region: ${{ inputs.region }}
+        aws-region: ${{ inputs.aws_region }}
 
     - name: CDK Deploy
       run: npx cdk deploy --require-approval never "*"

--- a/.github/workflows/deploy_with_cdk.yml
+++ b/.github/workflows/deploy_with_cdk.yml
@@ -3,6 +3,7 @@ name: Deploy with CDK
 
 permissions:
   id-token: write
+  contents: read
 
 on:
   # Runs workflow when called from another workflow (referred to as a "called" workflow)

--- a/.github/workflows/deploy_with_cdk.yml
+++ b/.github/workflows/deploy_with_cdk.yml
@@ -1,6 +1,10 @@
 # Deploys using CDK
 name: Deploy with CDK
 
+permissions:
+  id-token: write
+  contents: read
+
 on:
   # Runs workflow when called from another workflow (referred to as a "called" workflow)
   workflow_call:

--- a/.github/workflows/deploy_with_cdk.yml
+++ b/.github/workflows/deploy_with_cdk.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Install nodejs
       uses: actions/setup-node@v3
       with:
-        node-version: '16'
+        node-version: '18'
         registry-url: https://npm.pkg.github.com
         scope: "@epoxy-ai"
       env:

--- a/.github/workflows/deploy_with_cdk.yml
+++ b/.github/workflows/deploy_with_cdk.yml
@@ -1,6 +1,9 @@
 # Deploys using CDK
 name: Deploy with CDK
 
+permissions:
+  id-token: write
+
 on:
   # Runs workflow when called from another workflow (referred to as a "called" workflow)
   workflow_call:

--- a/.github/workflows/get_outputs_from_cloudformation_stack.yml
+++ b/.github/workflows/get_outputs_from_cloudformation_stack.yml
@@ -1,5 +1,8 @@
 name: Get outputs from a cloudformation stack and create a .stack_outputs artifact
 
+permissions:
+  id-token: write
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/get_outputs_from_cloudformation_stack.yml
+++ b/.github/workflows/get_outputs_from_cloudformation_stack.yml
@@ -2,31 +2,36 @@ name: Get outputs from a cloudformation stack and create a .stack_outputs artifa
 
 on:
   workflow_call:
-    secrets:
-      aws_secret_access_key:
-        required: true
-      aws_access_key_id:
-        required: true
-      aws_region:
-        required: true
     inputs:
       outputs:
         description: A comma-delimited string of stack Output names to be fetched
         required: true
         type: string
+      region:
+        required: true
+        type: string
+      aws_role_to_assume:
+        required: true
+        type: string
+      aws_role_duration_seconds:
+        required: false
+        type: number
+        default: 1200
 
 jobs:
   create_stack_outputs_artifact:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout codebase
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1-node16
         with:
-          aws-access-key-id: ${{ secrets.aws_access_key_id }}
-          aws-secret-access-key: ${{ secrets.aws_secret_access_key }}
-          aws-region: ${{ secrets.aws_region }}
+          role-to-assume: ${{ inputs.aws_role_to_assume }}
+          role-duration-seconds: ${{ inputs.aws_role_duration_seconds }} 
+          aws-region: ${{ inputs.region }}
+
       - name: Get and export the Cloudformation stack outputs
         env:
           OUTPUTS_TO_FETCH: ${{ inputs.outputs }}
@@ -59,6 +64,7 @@ jobs:
             echo "### :red_circle: No output values from in stack, goodbye." >> $GITHUB_STEP_SUMMARY
             exit 126
           fi
+
       - name: Upload .stack_outputs artifact
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/get_outputs_from_cloudformation_stack.yml
+++ b/.github/workflows/get_outputs_from_cloudformation_stack.yml
@@ -10,7 +10,7 @@ on:
         description: A comma-delimited string of stack Output names to be fetched
         required: true
         type: string
-      region:
+      aws_region:
         required: true
         type: string
       aws_role_to_assume:
@@ -33,7 +33,7 @@ jobs:
         with:
           role-to-assume: ${{ inputs.aws_role_to_assume }}
           role-duration-seconds: ${{ inputs.aws_role_duration_seconds }} 
-          aws-region: ${{ inputs.region }}
+          aws-region: ${{ inputs.aws_region }}
 
       - name: Get and export the Cloudformation stack outputs
         env:

--- a/.github/workflows/get_outputs_from_cloudformation_stack_v2.yml
+++ b/.github/workflows/get_outputs_from_cloudformation_stack_v2.yml
@@ -3,18 +3,21 @@ name: Get outputs from a cloudformation stack by 'service' field and create a .s
 
 on:
   workflow_call:
-    secrets:
-      aws_secret_access_key:
-        required: true
-      aws_access_key_id:
-        required: true
-      aws_region:
-        required: true
     inputs:
       outputs:
         description: A comma-delimited string of stack Output names to be fetched
         required: true
         type: string
+      aws_region:
+        required: true
+        type: string
+      aws_role_to_assume:
+        required: true
+        type: string
+      aws_role_duration_seconds:
+        required: false
+        type: number
+        default: 1200
 
 jobs:
   create_stack_outputs_artifact:
@@ -25,8 +28,8 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1-node16
         with:
-          aws-access-key-id: ${{ secrets.aws_access_key_id }}
-          aws-secret-access-key: ${{ secrets.aws_secret_access_key }}
+          role-to-assume: ${{ inputs.aws_role_to_assume }}
+          role-duration-seconds: ${{ inputs.aws_role_duration_seconds }}
           aws-region: ${{ secrets.aws_region }}
       - name: Get and export the Cloudformation stack outputs
         env:

--- a/.github/workflows/get_outputs_from_cloudformation_stack_v2.yml
+++ b/.github/workflows/get_outputs_from_cloudformation_stack_v2.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           role-to-assume: ${{ inputs.aws_role_to_assume }}
           role-duration-seconds: ${{ inputs.aws_role_duration_seconds }}
-          aws-region: ${{ secrets.aws_region }}
+          aws-region: ${{ inputs.aws_region }}
       - name: Get and export the Cloudformation stack outputs
         env:
           OUTPUTS_TO_FETCH: ${{ inputs.outputs }}

--- a/.github/workflows/get_outputs_from_cloudformation_stack_v3.yml
+++ b/.github/workflows/get_outputs_from_cloudformation_stack_v3.yml
@@ -1,0 +1,71 @@
+# Use this version if your project uses a stack name in the format `${service}${environment}${operator}`
+name: Get outputs from a cloudformation stack by 'service', 'environment', and 'operator' field and create a .stack_outputs artifact
+
+on:
+  workflow_call:
+    inputs:
+      outputs:
+        description: A comma-delimited string of stack Output names to be fetched
+        required: true
+        type: string
+      aws_region:
+        required: true
+        type: string
+      aws_role_to_assume:
+        required: true
+        type: string
+      aws_role_duration_seconds:
+        required: false
+        type: number
+        default: 1200
+
+jobs:
+  create_stack_outputs_artifact:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout codebase
+        uses: actions/checkout@v3
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1-node16
+        with:
+          role-to-assume: ${{ inputs.aws_role_to_assume }}
+          role-duration-seconds: ${{ inputs.aws_role_duration_seconds }}
+          aws-region: ${{ inputs.aws_region }}
+      - name: Get and export the Cloudformation stack outputs
+        env:
+          OUTPUTS_TO_FETCH: ${{ inputs.outputs }}
+        run: |
+          set -eo pipefail
+
+          # Get the current branch either from CI environment or from locally checked out branch
+          CURRENT_GIT_BRANCH="${GITHUB_HEAD_REF:-$(git symbolic-ref --short HEAD)}"
+
+          # Build stackId from cdk.json
+          STACK_ID=$(jq -r --arg CURRENT_GIT_BRANCH "$CURRENT_GIT_BRANCH" '.context.globals + (.context.environments[] | select(.branchName | contains($CURRENT_GIT_BRANCH))) | "\(.service)\(.environment | (.[:1] | ascii_upcase) + (.[1:]))\(.operator | (.[:1] | ascii_upcase) + (.[1:]))"' cdk.json)
+
+          # Check that stackId is available and explicitly set it to a new variable
+          if [[ -z "${STACK_ID}" ]]; then
+            echo "### :red_circle: No stackId value found, goodbye." >> $GITHUB_STEP_SUMMARY
+            exit 126
+          else
+            : # noop
+          fi
+
+          # Get the data from AWS Cloudformation
+          GREP_INPUTS=$(echo ${OUTPUTS_TO_FETCH} | sed "s/,/\\\|/g")
+          aws cloudformation describe-stacks --stack-name ${STACK_ID} --query "Stacks[0].Outputs[]" | jq -r '.[] | "\(.OutputKey)=\(.OutputValue)"' | grep ${GREP_INPUTS} > .stack_outputs
+
+          # Check that output values were found and set on GITHUB_ENV
+          if [ -s .stack_outputs ]; then
+            echo "### :white_check_mark: .stack_outputs file created:" >> $GITHUB_STEP_SUMMARY
+            cat .stack_outputs >> $GITHUB_STEP_SUMMARY
+          else
+            echo "### :red_circle: No output values from in stack, goodbye." >> $GITHUB_STEP_SUMMARY
+            exit 126
+          fi
+      - name: Upload .stack_outputs artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: stack_outputs
+          path: ${{ github.workspace }}/.stack_outputs
+          retention-days: 5

--- a/.github/workflows/run_cdk_tests.yaml
+++ b/.github/workflows/run_cdk_tests.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Install nodejs
         uses: actions/setup-node@v3
         with:
-          node-version: '16'
+          node-version: '18'
           registry-url: https://npm.pkg.github.com
           scope: "@epoxy-ai"
         env:

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install nodejs
         uses: actions/setup-node@v3
         with:
-          node-version: '16'
+          node-version: '18'
           registry-url: https://npm.pkg.github.com
           scope: "@epoxy-ai"
         env:

--- a/.github/workflows/upload_artifact_to_s3.yml
+++ b/.github/workflows/upload_artifact_to_s3.yml
@@ -5,16 +5,19 @@ on:
     secrets:
       gh_token:
         required: true
-      aws_access_key_id:
-        required: true
-      aws_secret_access_key:
-        required: true
       s3_bucket:
         required: true
     inputs:
-      region:
+      aws_region:
         required: true
         type: string
+      aws_role_to_assume:
+        required: true
+        type: string
+      aws_role_duration_seconds:
+        required: false
+        type: number
+        default: 1200
       artifact_name:
         required: true
         type: string
@@ -36,8 +39,8 @@ jobs:
       - name: Install configure-aws-credentials
         uses: aws-actions/configure-aws-credentials@v1-node16
         with:
-          aws-access-key-id: ${{ secrets.aws_access_key_id }}
-          aws-secret-access-key: ${{ secrets.aws_secret_access_key }}
-          aws-region: ${{ inputs.region }}
+          role-to-assume: ${{ inputs.aws_role_to_assume }}
+          role-duration-seconds: ${{ inputs.aws_role_duration_seconds }} 
+          aws-region: ${{ inputs.aws_region }}
       - name: Upload API spec file to s3
         run: aws s3 cp ${{ inputs.artifact_name }} s3://${{ secrets.s3_bucket }}/${{ inputs.artifact_name }}

--- a/.github/workflows/upload_artifact_to_s3.yml
+++ b/.github/workflows/upload_artifact_to_s3.yml
@@ -1,5 +1,9 @@
 name: Upload an artifact to an S3 bucket
 
+permissions:
+  id-token: write
+  contents: read
+
 on:
   workflow_call:
     secrets:

--- a/.github/workflows/upload_file_to_s3.yml
+++ b/.github/workflows/upload_file_to_s3.yml
@@ -1,20 +1,27 @@
 name: Upload a file to an S3 bucket
 
+permissions:
+  id-token: write
+  contents: read
+  
 on:
   workflow_call:
     secrets:
       gh_token:
         required: true
-      aws_access_key_id:
-        required: true
-      aws_secret_access_key:
-        required: true
       s3_bucket:
         required: true
     inputs:
-      region:
+      aws_region:
         required: true
         type: string
+      aws_role_to_assume:
+        required: true
+        type: string
+      aws_role_duration_seconds:
+        required: false
+        type: number
+        default: 1200
       source_file:
         required: true
         type: string
@@ -35,9 +42,9 @@ jobs:
       - name: Install configure-aws-credentials
         uses: aws-actions/configure-aws-credentials@v1-node16
         with:
-          aws-access-key-id: ${{ secrets.aws_access_key_id }}
-          aws-secret-access-key: ${{ secrets.aws_secret_access_key }}
-          aws-region: ${{ inputs.region }}
+          role-to-assume: ${{ inputs.aws_role_to_assume }}
+          role-duration-seconds: ${{ inputs.aws_role_duration_seconds }}
+          aws-region: ${{ inputs.aws_region }}
       - name: Upload API spec file to s3
         run: |
           if [ -z "${{ inputs.destination_file }}" ] # length of destination_file is zero


### PR DESCRIPTION
Merging this will put the following changes into the standard distribution _immediately_:

* only aws OIDC supported
* node18 for all reusable actions
* `get_outputs_from_cloudformation_stack_v3` which supports an alternative `stackId` format from v2