### PR TITLE
ci: update run_cdk_tests.yaml

### DIFF
--- a/.github/workflows/run_cdk_tests.yaml
+++ b/.github/workflows/run_cdk_tests.yaml
@@ -15,10 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout codebase
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install nodejs
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: '18'
           registry-url: https://npm.pkg.github.com


### PR DESCRIPTION
Increase underlying dependencies from `v3 -> v4` to avoid node 16 deprecation warnings from ghactions