### PR TITLE
chore: setup-node action uses node 22

### DIFF
--- a/.github/workflows/deploy_with_cdk.yml
+++ b/.github/workflows/deploy_with_cdk.yml
@@ -35,7 +35,7 @@ jobs:
     - name: Install nodejs
       uses: actions/setup-node@v4
       with:
-        node-version: '18'
+        node-version: '22'
         registry-url: https://npm.pkg.github.com
         scope: "@epoxy-ai"
       env:

--- a/.github/workflows/run_cdk_tests.yaml
+++ b/.github/workflows/run_cdk_tests.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Install nodejs
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '22'
           registry-url: https://npm.pkg.github.com
           scope: "@epoxy-ai"
         env:

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install nodejs
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '22'
           registry-url: https://npm.pkg.github.com
           scope: "@epoxy-ai"
         env:


### PR DESCRIPTION
A repo that uses these workflows should expect node 22 when things like `npm ci` run.